### PR TITLE
Calculate the maximum Absolute Value for large negative data points

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,10 +142,10 @@ function string(out) {
  */
 
 function max(data) {
-  var n = data[0];
+  var n = Math.abs(data[0]);
 
   for (var i = 1; i < data.length; i++) {
-    n = data[i] > n ? data[i] : n;
+    n = Math.abs(data[i]) > n ? Math.abs(data[i]) : n;
   }
 
   return n;


### PR DESCRIPTION
The chart generation [inverts negative values](https://github.com/jstrace/chart/blob/master/index.js#L95). This cause an [undefined array index](https://github.com/jstrace/chart/blob/master/index.js#L98) error when the lowest value has a greater magnitude than the maximum (ie charts of negative values). To get the proper scaling, the negative values must be considered when computing the scaling maximum.

This small fix removes errors on negative maxima
